### PR TITLE
[#25] 2.1.2 구독 SW 전체 조회 및 검색

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,6 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.projectlombok:lombok:1.18.20'
-    implementation 'org.projectlombok:lombok:1.18.20'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.modelmapper:modelmapper:2.4.2'
     implementation 'junit:junit:4.13.1'
@@ -24,10 +23,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
     implementation 'mysql:mysql-connector-java'
+
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
     testAnnotationProcessor('org.projectlombok:lombok')
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/gp/cnusambe/controller/SubscriptionSWController.java
+++ b/src/main/java/gp/cnusambe/controller/SubscriptionSWController.java
@@ -11,6 +11,7 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @RestController
@@ -22,15 +23,17 @@ public class SubscriptionSWController {
         return new ResponseEntity<>(subscriptionSWService.createSubscriptionSW(request), HttpStatus.OK);
     }
 
-    @GetMapping("/subscriptions")
+    @GetMapping("/subscriptions/search")
     public ResponseEntity<Page<SubscriptionSWResponse>> getAllSubscriptionSW(
-            @RequestParam(value="search", required=false) boolean search,
             @RequestParam(value="sw-type", required=false) String swType,
             @RequestParam(value="sw-mfr", required=false) String swManufacturer,
             @RequestParam(value="sw-name", required=false) String swName,
-            @PageableDefault(size=9, page = 0, sort = "latestUpdateDate", direction = Sort.Direction.DESC) Pageable pageable
+            @PageableDefault(size=9, page=0, sort="latestUpdateDate", direction=Sort.Direction.DESC) Pageable pageable
     ){
-        return new ResponseEntity<>(subscriptionSWService.readAllSubscriptionSW(search, swType, swManufacturer, swName, pageable), HttpStatus.OK);
+        String swType_ = Optional.ofNullable(swType).orElse("");
+        String swManufacturer_ = Optional.ofNullable(swManufacturer).orElse("");
+        String swName_ = Optional.ofNullable(swName).orElse("");
+        return new ResponseEntity<>(subscriptionSWService.readAllSubscriptionSW(swType_, swManufacturer_, swName_, pageable), HttpStatus.OK);
     }
 
     @DeleteMapping("/subscriptions/{ssw_id}")

--- a/src/main/java/gp/cnusambe/controller/SubscriptionSWController.java
+++ b/src/main/java/gp/cnusambe/controller/SubscriptionSWController.java
@@ -1,11 +1,13 @@
 package gp.cnusambe.controller;
 
-import gp.cnusambe.domain.SubscriptionSW;
 import gp.cnusambe.payload.request.SubscriptionSWRequest;
 import gp.cnusambe.payload.response.SubscriptionSWResponse;
 import gp.cnusambe.service.SubscriptionSWService;
 import lombok.RequiredArgsConstructor;
-import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -14,12 +16,21 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 public class SubscriptionSWController {
     private final SubscriptionSWService subscriptionSWService;
-    private final ModelMapper modelMapper = new ModelMapper();
 
     @PostMapping("/subscriptions")
     public ResponseEntity<SubscriptionSWResponse> postSubscriptionSW(@RequestBody SubscriptionSWRequest request){
-        SubscriptionSW sw = subscriptionSWService.createSubscriptionSW(request);
-        return new ResponseEntity<>(modelMapper.map(sw, SubscriptionSWResponse.class), HttpStatus.OK);
+        return new ResponseEntity<>(subscriptionSWService.createSubscriptionSW(request), HttpStatus.OK);
+    }
+
+    @GetMapping("/subscriptions")
+    public ResponseEntity<Page<SubscriptionSWResponse>> getAllSubscriptionSW(
+            @RequestParam(value="search", required=false) boolean search,
+            @RequestParam(value="sw-type", required=false) String swType,
+            @RequestParam(value="sw-mfr", required=false) String swManufacturer,
+            @RequestParam(value="sw-name", required=false) String swName,
+            @PageableDefault(size=9, page = 0, sort = "latestUpdateDate", direction = Sort.Direction.DESC) Pageable pageable
+    ){
+        return new ResponseEntity<>(subscriptionSWService.readAllSubscriptionSW(search, swType, swManufacturer, swName, pageable), HttpStatus.OK);
     }
 
     @DeleteMapping("/subscriptions/{ssw_id}")

--- a/src/main/java/gp/cnusambe/repository/SubscriptionSWRepository.java
+++ b/src/main/java/gp/cnusambe/repository/SubscriptionSWRepository.java
@@ -1,9 +1,14 @@
 package gp.cnusambe.repository;
 
 import gp.cnusambe.domain.SubscriptionSW;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import java.util.Optional;
 
-public interface SubscriptionSWRepository extends JpaRepository<SubscriptionSW, Long> {
+public interface SubscriptionSWRepository extends JpaRepository<SubscriptionSW, Long>, JpaSpecificationExecutor<SubscriptionSW>  {
     Optional<SubscriptionSW> findById(Long swId);
+    Page<SubscriptionSW> findAll(Specification spec, Pageable pageable);
 }

--- a/src/main/java/gp/cnusambe/repository/SwSubscriptionQueryRepository.java
+++ b/src/main/java/gp/cnusambe/repository/SwSubscriptionQueryRepository.java
@@ -1,0 +1,41 @@
+package gp.cnusambe.repository;
+
+import gp.cnusambe.domain.SubscriptionSW;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Repository;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class SwSubscriptionQueryRepository {
+    private final SubscriptionSWRepository subscriptionSWRepository;
+
+    public Page<SubscriptionSW> findAllBy(String swType, String swManufacturer, String swName, Pageable pageable) {
+        Optional<String> swType_ = Optional.ofNullable(swType);
+        Optional<String> swManufacturer_ = Optional.ofNullable(swManufacturer);
+        Optional<String> swName_ = Optional.ofNullable(swName);
+
+        Specification<SubscriptionSW> spec
+                = Specification.where(likeData("swType", swType_.orElse("")))
+                .and(likeData("swManufacturer", swManufacturer_.orElse("")))
+                .and(likeData("swName", swName_.orElse("")));
+
+        return subscriptionSWRepository.findAll(spec, pageable);
+    }
+
+    static private Specification<SubscriptionSW> likeData(String dataType, String data) {
+        return new Specification<SubscriptionSW>() {
+            @Override
+            public Predicate toPredicate(Root<SubscriptionSW> root, CriteriaQuery<?> query, CriteriaBuilder criteriaBuilder) {
+                return criteriaBuilder.like(root.get(dataType), "%" + data + "%");
+            }
+        };
+    }
+}

--- a/src/main/java/gp/cnusambe/repository/SwSubscriptionQueryRepository.java
+++ b/src/main/java/gp/cnusambe/repository/SwSubscriptionQueryRepository.java
@@ -18,15 +18,10 @@ public class SwSubscriptionQueryRepository {
     private final SubscriptionSWRepository subscriptionSWRepository;
 
     public Page<SubscriptionSW> findAllBy(String swType, String swManufacturer, String swName, Pageable pageable) {
-        Optional<String> swType_ = Optional.ofNullable(swType);
-        Optional<String> swManufacturer_ = Optional.ofNullable(swManufacturer);
-        Optional<String> swName_ = Optional.ofNullable(swName);
-
         Specification<SubscriptionSW> spec
-                = Specification.where(likeData("swType", swType_.orElse("")))
-                .and(likeData("swManufacturer", swManufacturer_.orElse("")))
-                .and(likeData("swName", swName_.orElse("")));
-
+                = Specification.where(likeData("swType", swType))
+                .and(likeData("swManufacturer", swManufacturer))
+                .and(likeData("swName", swName));
         return subscriptionSWRepository.findAll(spec, pageable);
     }
 

--- a/src/main/java/gp/cnusambe/service/SubscriptionSWService.java
+++ b/src/main/java/gp/cnusambe/service/SubscriptionSWService.java
@@ -25,7 +25,8 @@ public class SubscriptionSWService {
     }
 
     public Page<SubscriptionSWResponse> readAllSubscriptionSW
-            (boolean search, String swType, String swManufacturer, String swName, Pageable pageable) {
+            (String swType, String swManufacturer, String swName, Pageable pageable) {
+        boolean search = swType.length()==0 && swManufacturer.length()==0 & swName.length()==0 ? false : true;
         Page<SubscriptionSW> sw = search
                 ? swSubscriptionQueryRepository.findAllBy(swType, swManufacturer, swName, pageable)
                 : subscriptionSWRepository.findAll(pageable);

--- a/src/main/java/gp/cnusambe/service/SubscriptionSWService.java
+++ b/src/main/java/gp/cnusambe/service/SubscriptionSWService.java
@@ -3,21 +3,36 @@ package gp.cnusambe.service;
 import gp.cnusambe.domain.SubscriptionSW;
 import gp.cnusambe.exception.custom.SWNotFoundException;
 import gp.cnusambe.payload.request.SubscriptionSWRequest;
+import gp.cnusambe.payload.response.SubscriptionSWResponse;
 import gp.cnusambe.repository.SubscriptionSWRepository;
+import gp.cnusambe.repository.SwSubscriptionQueryRepository;
 import lombok.RequiredArgsConstructor;
+import org.modelmapper.ModelMapper;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class SubscriptionSWService {
+    private final ModelMapper modelMapper;
     private final SubscriptionSWRepository subscriptionSWRepository;
+    private final SwSubscriptionQueryRepository swSubscriptionQueryRepository;
 
-    public SubscriptionSW createSubscriptionSW(SubscriptionSWRequest request){
-        SubscriptionSW sw = new SubscriptionSW(request);
-        return subscriptionSWRepository.save(sw);
+    public SubscriptionSWResponse createSubscriptionSW(SubscriptionSWRequest request) {
+        SubscriptionSW sw = subscriptionSWRepository.save(new SubscriptionSW(request));
+        return modelMapper.map(sw, SubscriptionSWResponse.class);
     }
 
-    public void deleteSubscriptionSW(Long swId){
+    public Page<SubscriptionSWResponse> readAllSubscriptionSW
+            (boolean search, String swType, String swManufacturer, String swName, Pageable pageable) {
+        Page<SubscriptionSW> sw = search
+                ? swSubscriptionQueryRepository.findAllBy(swType, swManufacturer, swName, pageable)
+                : subscriptionSWRepository.findAll(pageable);
+        return sw.map(element -> modelMapper.map(element, SubscriptionSWResponse.class));
+    }
+
+    public void deleteSubscriptionSW(Long swId) {
         SubscriptionSW sw = subscriptionSWRepository.findById(swId).orElseThrow(SWNotFoundException::new);
         subscriptionSWRepository.delete(sw);
     }


### PR DESCRIPTION
## what to do
- 구독 SW 전체 조회 및 검색 기능 구현
- 최근 생성 순으로 정렬, 페이지도 확인
- query는 like조건으로, 검색 단어가 존재하는 모든 sw들을 &조건으로 검색되도록 함
- 검색어는 sw-type, sw-mfr, sw-name

## related issues
#25 