### PR TITLE
[#75] OssLicenseListResponse : meta -> pageInfo로 변경

### DIFF
--- a/src/main/java/gp/cnusambe/payload/response/OssLicenseListResponse.java
+++ b/src/main/java/gp/cnusambe/payload/response/OssLicenseListResponse.java
@@ -13,7 +13,6 @@ import java.util.List;
 @AllArgsConstructor
 @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
 public class OssLicenseListResponse {
-    private PageInfoDto meta;
+    private PageInfoDto pageInfo;
     private List<OssLicenseDto> OssLicense;
-
 }


### PR DESCRIPTION
## what to do
- OssLicenseListResponse에서 meta 에서 pageInfo로 변수명 변경
## related issues
- #75 